### PR TITLE
Allow custom library extension for load()

### DIFF
--- a/cwrap/clib.py
+++ b/cwrap/clib.py
@@ -47,13 +47,15 @@ so_extension = {"linux"  : "so",
 # the current runnning process, i.e. like dlopen( NULL ). We must
 # special case this to avoid creating the bogus argument 'None.so'.
 
-def lib_name(lib , path = None , so_version = ""):
+def lib_name(lib , path = None , so_version = "", so_ext = None):
     if lib is None:
         return None
     else:
         platform_key = platform.system().lower()
 
-        if platform_key == "darwin":
+        if so_ext:
+            so_name = "%s.%s%s" % (lib, so_ext, so_version)
+        elif platform_key == "darwin":
             so_name = "%s%s.%s" % (lib, so_version, so_extension[ platform_key ])
         else:
             so_name = "%s.%s%s" % (lib, so_extension[ platform_key ], so_version)
@@ -66,7 +68,7 @@ def lib_name(lib , path = None , so_version = ""):
 
 
 
-def load( lib, so_version = None, path = None):
+def load( lib, so_version = None, path = None, so_ext = None):
     """Thin wrapper around the ctypes.CDLL function for loading shared
     library.
 
@@ -77,8 +79,13 @@ def load( lib, so_version = None, path = None):
 
     dll = None
     lib_files = [ lib_name( lib , path = path , so_version = so_version) ]
+
+    if so_ext:
+        lib_files.append( lib_name( lib, path = path, so_version = so_version, so_ext = so_ext ) )
+
     if path:
-        lib_files.append( lib_name( lib , path = None , so_version = so_version) )
+        lib_files.append( lib_name( lib , path = None , so_version = so_version ) )
+        lib_files.append( lib_name( lib , path = None , so_version = so_version, so_ext = so_ext ) )
 
     for lib_file in lib_files:
         try:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ library https://github.com/statoil/libecl, but isn't tied to it.
 """
 
 setup(name='cwrap',
-      version='1.0.0',
+      version='1.1.0',
       description='cwrap - ctypes blanket',
       long_description=long_description,
       author='Statoil ASA',


### PR DESCRIPTION
In some configurations, libraries get the .so extension on Darwin, or
using a custom extension is desired. This is supported by the optional
parameter so_ext which ignores the platform lookup logic and just sets
the extension.