### PR TITLE
Respect LD_LIBRARY_PATH

### DIFF
--- a/cwrap/clib.py
+++ b/cwrap/clib.py
@@ -78,14 +78,11 @@ def load( lib, so_version = None, path = None, so_ext = None):
     """
 
     dll = None
-    lib_files = [ lib_name( lib , path = path , so_version = so_version) ]
-
-    if so_ext:
-        lib_files.append( lib_name( lib, path = path, so_version = so_version, so_ext = so_ext ) )
-
-    if path:
-        lib_files.append( lib_name( lib , path = None , so_version = so_version ) )
-        lib_files.append( lib_name( lib , path = None , so_version = so_version, so_ext = so_ext ) )
+    lib_files = [ lib_name( lib, path = None, so_version = so_version ),
+                  lib_name( lib, path = None, so_version = so_version, so_ext = so_ext ),
+                  lib_name( lib, path = path, so_version = so_version ),
+                  lib_name( lib, path = path, so_version = so_version, so_ext = so_ext )
+                ]
 
     for lib_file in lib_files:
         try:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ library https://github.com/statoil/libecl, but isn't tied to it.
 """
 
 setup(name='cwrap',
-      version='1.1.1',
+      version='1.1.2',
       description='cwrap - ctypes blanket',
       long_description=long_description,
       author='Statoil ASA',


### PR DESCRIPTION
Prefer the library found through LD_LIBRARY_PATH, over the one provided
by the path argument, so that users can select a different copy of the
library to use, and fall back to the hard-coded path argument only when
no LD_LIBRARY_PATH can be found.