### PR TITLE
Get version from git-tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# don't track setuptools-generated version
+cwrap/version.py

--- a/cwrap/__init__.py
+++ b/cwrap/__init__.py
@@ -28,11 +28,13 @@ the process of interacting with a C library:
      FILE pointer.
 """
 
+try: from .version import version as __version__
+except ImportError: __version__ = '0.0.0'
+
 __author__ = 'Jean-Paul Balabanian, Joakim Hove, and PG Drange'
 __copyright__ = 'Copyright 2016, Statoil ASA'
 __credits__ = __author__
 __license__ = 'GPL'
-__version__ = '1.1.1'
 __maintainer__ = __author__
 __email__ = __author__
 __status__ = 'Prototype'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ library https://github.com/statoil/libecl, but isn't tied to it.
 """
 
 setup(name='cwrap',
-      version='1.1.2',
+      use_scm_version={'write_to': 'cwrap/version.py' },
       description='cwrap - ctypes blanket',
       long_description=long_description,
       author='Statoil ASA',


### PR DESCRIPTION
When building, create versions based on git info. This makes it possible
to actually keep version numbers in sync, which otherwise would have to
be set in correct order in three (!) different places.

I personally messed this up twice till now.