### PR TITLE
Make cwrap Python3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: python
+python:
+    - "2.7"
+    - "3.6"
+
+os:
+    - linux
+    # - osx
 
 install:
   - pip install -r requirements.txt

--- a/cwrap/__init__.py
+++ b/cwrap/__init__.py
@@ -31,23 +31,23 @@ the process of interacting with a C library:
 try: from .version import version as __version__
 except ImportError: __version__ = '0.0.0'
 
-__author__ = 'Jean-Paul Balabanian, Joakim Hove, and PG Drange'
+__author__ = 'Statoil ASA'
 __copyright__ = 'Copyright 2016, Statoil ASA'
 __credits__ = __author__
 __license__ = 'GPL'
 __maintainer__ = __author__
-__email__ = __author__
+__email__ = 'fg_gpl@statoil.com'
 __status__ = 'Prototype'
 
 from .basecclass import BaseCClass
 from .basecenum import BaseCEnum
 from .basecvalue import BaseCValue
 
-from .cfile import CFILE
+from .cfile import CFILE, copen as open
 from .clib import load, lib_name
 
 from .metacwrap import MetaCWrap
 from .prototype import REGISTERED_TYPES, Prototype, PrototypeError
 
-__all__ = ['BaseCClass', 'BaseCEnum', 'BaseCValue', 'CFILE',
+__all__ = ['BaseCClass', 'BaseCEnum', 'BaseCValue', 'CFILE', 'open',
            'MetaCWrap', 'Prototype', 'load', 'lib_name']

--- a/cwrap/cfile.py
+++ b/cwrap/cfile.py
@@ -14,57 +14,159 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-import ctypes
 import six
-from .prototype import Prototype, PrototypeError
+import sys
+from .prototype import Prototype
 from .basecclass import BaseCClass
 
-class CFILE(BaseCClass):
-    """
-    Utility class to map a Python file handle <-> FILE* in C
-    """
-    TYPE_NAME = "FILE"
 
-    _as_file = Prototype(ctypes.pythonapi, "void* PyFile_AsFile(py_object)")
+if six.PY2:
+    import ctypes
 
-    def __init__(self, py_file):
+    def copen(filename, mode='r'):
         """
-        Takes a python file handle and looks up the underlying FILE *
+        This is a compatibility layer for functions taking FILE* pointers, and
+        should not be used unless absolutely needed.
 
-        The purpose of the CFILE class is to be able to use python
-        file handles when calling C functions which expect a FILE
-        pointer. A CFILE instance should be created based on the
-        Python file handle, and that should be passed to the function
-        expecting a FILE pointer.
-
-        The implementation is based on the ctypes object
-        pythonapi which is ctypes wrapping of the CPython api.
-
-          C-function:
-             void fprintf_hello(FILE * stream , const char * msg);
-
-          Python wrapper:
-             lib = clib.load( "lib.so" )
-             fprintf_hello = Prototype(lib, "void fprintf_hello( FILE , char* )")
-
-          Python use:
-             py_fileH = open("file.txt" , "w")
-             fprintf_hello( CFILE( py_fileH ) , "Message ...")
-             py_fileH.close()
-
-        If the supplied argument is not of type py_file the function
-        will raise a TypeException.
-
-        Examples: ecl.ecl.ecl_kw.EclKW.fprintf_grdecl()
+        In Python 2 this function is simply an alias for open. In Python 3,
+        however, it returns an instance of CWrapFile, a very light weight
+        wrapper around a FILE* instance.
         """
-        c_ptr = self._as_file(py_file)
-        try:
-            super(CFILE, self).__init__(c_ptr)
-        except ValueError as e:
-            raise TypeError("Sorry - the supplied argument is not a valid Python file handle!")
+        return open(filename, mode)
 
-        self.py_file = py_file
+    class CFILE(BaseCClass):
+        """
+        Utility class to map a Python file handle <-> FILE* in C
+        """
+        TYPE_NAME = "FILE"
+
+        _as_file = Prototype(ctypes.pythonapi, "void* PyFile_AsFile(py_object)")
+
+        def __init__(self, py_file):
+            """
+            Takes a python file handle and looks up the underlying FILE *
+
+            The purpose of the CFILE class is to be able to use python
+            file handles when calling C functions which expect a FILE
+            pointer. A CFILE instance should be created based on the
+            Python file handle, and that should be passed to the function
+            expecting a FILE pointer.
+
+            The implementation is based on the ctypes object
+            pythonapi which is ctypes wrapping of the CPython api.
+
+              C-function:
+                 void fprintf_hello(FILE * stream , const char * msg);
+
+              Python wrapper:
+                 lib = clib.load( "lib.so" )
+                 fprintf_hello = Prototype(lib, "void fprintf_hello( FILE , char* )")
+
+              Python use:
+                 py_fileH = open("file.txt" , "w")
+                 fprintf_hello( CFILE( py_fileH ) , "Message ...")
+                 py_fileH.close()
+
+            If the supplied argument is not of type py_file the function
+            will raise a TypeException.
+
+            Examples: ecl.ecl.ecl_kw.EclKW.fprintf_grdecl()
+            """
+            c_ptr = self._as_file(py_file)
+            try:
+                super(CFILE, self).__init__(c_ptr)
+            except ValueError:
+                raise TypeError("Sorry - the supplied argument is not a valid "
+                                " Python file handle!")
+
+            self.py_file = py_file
+
+        def __del__(self):
+            pass
 
 
-    def __del__(self):
-        pass
+if six.PY3:
+    from .clib import load as cwrapload
+
+    class LibcPrototype(Prototype):
+        lib = cwrapload(None)
+
+        def __init__(self, prototype, bind=False, allow_attribute_error=False):
+            super(LibcPrototype, self).__init__(
+                LibcPrototype.lib,
+                prototype,
+                bind=bind,
+                allow_attribute_error=allow_attribute_error)
+
+    def copen(filename, mode='r'):
+        """
+        This is a compatibility layer for functions taking FILE* pointers, and
+        should not be used unless absolutely needed.
+
+        In Python 2 this function is simply an alias for open. In Python 3,
+        however, it returns an instance of CWrapFile, a very lightweight
+        wrapper around a FILE* instance.
+        """
+        return CWrapFile(filename, mode)
+
+    class CWrapFile(BaseCClass):
+        """
+        This is a compatibility layer for functions taking FILE* pointers, and
+        should not be used unless absolutely needed.
+
+        CWrapFile is a very lightweight wrapper around FILE* instances. It is
+        meant be used inplace of python file objects that are to be passed to
+        foreign function calls under python 3.
+
+        Example:
+            with cwrap.open('filename', 'mode') as f:
+                foreign_function_call(f)
+        """
+
+        TYPE_NAME = "FILE"
+
+        _fopen = LibcPrototype("void* fopen (char*, char*)")
+        _fclose = LibcPrototype("int fclose (FILE)", bind=True)
+        _fflush = LibcPrototype("int fflush (FILE)", bind=True)
+
+        def __init__(self, fname, mode):
+            c_ptr = self._fopen(fname, mode)
+            self._mode = mode
+            self._fname = fname
+            self._closed = False
+
+            try:
+                super(CWrapFile, self).__init__(c_ptr)
+            except ValueError:
+                self._closed = True
+                raise IOError('Could not open file "{}" in mode {}'
+                              .format(fname, mode))
+
+        def close(self):
+            if not self._closed:
+                self._fflush()
+                cs = self._fclose()
+                if (cs != 0):
+                    raise IOError("Failed to close file")
+                self._closed = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.close()
+            return exc_type is None
+
+        def free(self):
+            self.close()
+
+        def __del__(self):
+            self.close()
+
+    def CFILE(f):
+        if not isinstance(f, CWrapFile):
+            raise TypeError("This function requires the use of CWrapFile, "
+                            "not {} when running Python 3. See "
+                            "help(cwrap.open) for more info"
+                            .format(type(f).__name__))
+        return f

--- a/cwrap/metacwrap.py
+++ b/cwrap/metacwrap.py
@@ -56,8 +56,3 @@ class MetaCWrap(type):
             if isinstance(attr, Prototype):
                 attr.resolve()
                 attr.__name__ = key
-
-                if attr.shouldBeBound():
-                    method = MethodType(attr, None, cls)
-                    #method = six.create_bound_method(attr, cls)
-                    setattr(cls, key, method)

--- a/tests/test_basecclass.py
+++ b/tests/test_basecclass.py
@@ -5,9 +5,6 @@ from cwrap import BaseCClass
 
 class BaseCClassTest(unittest.TestCase):
 
-    def test_none_assertion(self):
-        self.assertFalse(None > 0)
-
     def test_creation(self):
         with self.assertRaises(ValueError):
             obj = BaseCClass(0)

--- a/tests/test_cfile.py
+++ b/tests/test_cfile.py
@@ -4,7 +4,7 @@ import tempfile
 
 import unittest
 
-from cwrap import Prototype, CFILE, load
+from cwrap import Prototype, CFILE, load, open as copen
 
 # Local copies so that the real ones don't get changed
 class TestUtilPrototype(Prototype):
@@ -25,15 +25,15 @@ class CFILETest(unittest.TestCase):
         with open("test", "w") as f:
             f.write("some content")
 
-        with open("test", "r") as f:
+        with copen("test", "r") as f:
             cfile = CFILE(f)
-            self.assertEqual(fileno(cfile), f.fileno())
+            self.assertTrue(fileno(cfile))
 
         os.chdir(cwd)
         shutil.rmtree( d )
 
 
-        
+
     def test_cfile_error(self):
         with self.assertRaises(TypeError):
             cfile = CFILE("some text")

--- a/tests/test_libc.py
+++ b/tests/test_libc.py
@@ -1,25 +1,30 @@
-import ctypes
 import unittest
 from cwrap import BaseCClass, Prototype, load
 
 
 class LibCPrototype(Prototype):
-    lib = load( None )
+    lib = load(None)
 
-    def __init__(self , prototype , bind = False, allow_attribute_error = False):
-        super(LibCPrototype , self).__init__( LibCPrototype.lib , prototype , bind = bind, allow_attribute_error = allow_attribute_error)
+    def __init__(self, prototype, bind=False, allow_attribute_error=False):
+        super(LibCPrototype, self).__init__(
+            LibCPrototype.lib,
+            prototype,
+            bind=bind,
+            allow_attribute_error=allow_attribute_error)
 
 
 class LibC(BaseCClass):
     TYPE_NAME = "void_libc_none"
     _malloc = LibCPrototype("void* malloc(void*)")
-    _abs    = LibCPrototype("int   abs(int)")
-    _atoi   = LibCPrototype("int   atoi(char*)")
-    _free   = LibCPrototype("void  free(void*)")
-    _missing_function = LibCPrototype("void  missing_function(int*)", allow_attribute_error = True)
+    _abs = LibCPrototype("int   abs(int)")
+    _atoi = LibCPrototype("int   atoi(char*)")
+    _strchr = LibCPrototype("char* strchr(char*, int)")
+    _free = LibCPrototype("void  free(void*)")
+    _missing_function = LibCPrototype("void  missing_function(int*)",
+                                      allow_attribute_error=True)
 
     def __init__(self):
-        c_ptr = 1#c_ptr = self._malloc(4)
+        c_ptr = 1  # c_ptr = self._malloc(4)
         super(LibC, self).__init__(c_ptr)
 
     def abs(self, x):
@@ -28,18 +33,24 @@ class LibC(BaseCClass):
     def atoi(self, s):
         return self._atoi(s)
 
+    def strchr(self, s, t):
+        return self._strchr(s, t)
+
     def free(self):
-        pass#self._free(self.__c_pointer)
+        pass  # self._free(self.__c_pointer)
+
 
 class LibCTest(unittest.TestCase):
 
     def test_libc(self):
-        lib = LibC( )
-        self.assertEqual( lib.abs(-3) , 3 )
-        self.assertEqual( lib.abs(0) , 0 )
-        self.assertEqual( lib.abs(42) , 42 )
-        self.assertEqual( lib.atoi("12") , 12)
-        self.assertEqual( lib.atoi("-100") , -100)
+        lib = LibC()
+        self.assertEqual(lib.abs(-3), 3)
+        self.assertEqual(lib.abs(0), 0)
+        self.assertEqual(lib.abs(42), 42)
+        self.assertEqual(lib.atoi("12"), 12)
+        self.assertEqual(lib.atoi("-100"), -100)
+        self.assertEqual(lib.strchr("a,b", ord(",")), ",b")
+        self.assertEqual(lib.strchr("a,b", ord("x")), None)
 
         with self.assertRaises(NotImplementedError):
-            lib._missing_function( 100 )
+            lib._missing_function(100)


### PR DESCRIPTION
In python 3, file streams are buffered on multiple levels which means
that it is no longer safe to extract a FILE* pointer from a python file
object. The old CFILE implementation can thus no longer be used. In
order to support function bindings that rely on the old python file to
FILE* mechanism, a thin compatibility layer is introduced.

char* strings from C can no longer be directly used as python str
objects. We therefor need to encode and decode str objects when passed
as arguments to or returned from foreign function calls.

The MethodType constructor in python 3 does not take a class as
argument. This is solved by deferring the construction to the functions
__get__ invocation, where we have access to the calling instance.