### PR TITLE
Fix for so_extension dict on Windows

### DIFF
--- a/cwrap/clib.py
+++ b/cwrap/clib.py
@@ -38,8 +38,7 @@ import os
 so_extension = {"linux"  : "so",
                 "linux2" : "so",
                 "linux3" : "so",
-                "win32"  : "dll",
-                "win64"  : "dll",
+                "windows": "dll",
                 "darwin" : "dylib" }
 
 


### PR DESCRIPTION
platform.system() returns "Windows" on Windows