### PR TITLE
Support Python 3 on Windows

### DIFF
--- a/cwrap/cfile.py
+++ b/cwrap/cfile.py
@@ -14,6 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+import os
 import six
 import sys
 from .prototype import Prototype
@@ -89,7 +90,8 @@ if six.PY3:
     from .clib import load as cwrapload
 
     class LibcPrototype(Prototype):
-        lib = cwrapload(None)
+        # Load the c standard library (on Linux passsing None does the trick)
+        lib = cwrapload('msvcrt' if os.name == 'nt' else None)
 
         def __init__(self, prototype, bind=False, allow_attribute_error=False):
             super(LibcPrototype, self).__init__(

--- a/cwrap/clib.py
+++ b/cwrap/clib.py
@@ -46,11 +46,13 @@ so_extension = {"linux"  : "so",
 # the current runnning process, i.e. like dlopen( NULL ). We must
 # special case this to avoid creating the bogus argument 'None.so'.
 
-def lib_name(lib , path = None , so_version = "", so_ext = None):
+def lib_name(lib , path = None , so_version = None, so_ext = None):
     if lib is None:
         return None
     else:
         platform_key = platform.system().lower()
+        if so_version is None:
+            so_version = ''
 
         if so_ext:
             so_name = "%s.%s%s" % (lib, so_ext, so_version)


### PR DESCRIPTION
On Linux, the implementation relied on an unexpected of `_ctypes.dlopen(lib)`  that would load the c standard library when `lib` is `None` (specifically it loads `libdl.so`). This is by itself questionable, but it seems to be working fine, so I am not touching that

On Windows, `_ctypes.LoadLibrary()` is called instead, which has a completely different behavior. In this PR, `msvcrt.dll` is loaded explicitly if we are on Windows
