### PR TITLE
Use ctypes.PyDLL instead of CDLL

### DIFF
--- a/cwrap/clib.py
+++ b/cwrap/clib.py
@@ -42,7 +42,7 @@ so_extension = {"linux"  : "so",
                 "darwin" : "dylib" }
 
 
-# Passing None to the CDLL() function means to open a lib handle to
+# Passing None to the PyDLL() function means to open a lib handle to
 # the current runnning process, i.e. like dlopen( NULL ). We must
 # special case this to avoid creating the bogus argument 'None.so'.
 
@@ -70,7 +70,7 @@ def lib_name(lib , path = None , so_version = None, so_ext = None):
 
 
 def load( lib, so_version = None, path = None, so_ext = None):
-    """Thin wrapper around the ctypes.CDLL function for loading shared
+    """Thin wrapper around the ctypes.PyDLL function for loading shared
     library.
 
     If the path argument is non Null the function will first try to
@@ -87,7 +87,7 @@ def load( lib, so_version = None, path = None, so_ext = None):
 
     for lib_file in lib_files:
         try:
-            dll = ctypes.CDLL(lib_file , ctypes.RTLD_GLOBAL)
+            dll = ctypes.PyDLL(lib_file, ctypes.RTLD_GLOBAL)
             return dll
         except Exception as exc:
             error = exc


### PR DESCRIPTION
Doing so will allow us to have the .so live as a Python module. This allows the
.so to export Python names and throw Python exceptions. However, using PyDLL
doesn't unlock the GIL when going to C functions. This could cause performance
problems or even deadlocks in applications that don't expect this.

https://docs.python.org/2/library/ctypes.html#ctypes.PyDLL

We could have this be an opt-in feature by checking if the library contains some
special symbol, eg:

```python
dll = ctypes.CDLL( ... )
if hasattr(dll, "__cwrap_python_module__"):
  dll = ctypes.PyDLL( ... )
```