### PR TITLE
Check for self != nullptr for bound prototypes

### DIFF
--- a/cwrap/prototype.py
+++ b/cwrap/prototype.py
@@ -215,6 +215,8 @@ class Prototype(object):
             else:
                 raise PrototypeError("Prototype has not been properly resolved")
         try:
+            if self.shouldBeBound() and not args[0]._address():
+                raise AttributeError("self is Null")
             return self._func(*args)
         except ctypes.ArgumentError as err:
             # Reraise the exception as TypeError with a suitable message


### PR DESCRIPTION
`self.__c_pointer` not being 0 is an invariant that is broken when a
constructor throws an exception before the object creation is finalised.
Avoid it by checking that the address of the first argument (self) is
non-null
