### PR TITLE
Fix ArgumentError handling

### DIFF
--- a/cwrap/prototype.py
+++ b/cwrap/prototype.py
@@ -223,7 +223,8 @@ class Prototype(object):
             # ArgumentError.message will look like this
             #   `argument 4: <type 'exceptions.TypeError'>: wrong type`
             # The only useful information here is the index of the argument 
-            tokens = re.split("[ :]", err.message)
+            errMsg = err.message if hasattr(err, "message") else str(err)
+            tokens = re.split("[ :]", errMsg)
             argidx = int(tokens[1]) - 1  # it starts from 1
             raise TypeError((
                 "Argument {argidx}: cannot create a {argtype} from the given "
@@ -233,7 +234,7 @@ class Prototype(object):
                         actval=repr(args[argidx]),
                         acttype=type(args[argidx]),
                         )
-                )
+                ) from err
 
     def __get__(self, instance, owner):
         if not self._resolved:

--- a/tests/test_libc.py
+++ b/tests/test_libc.py
@@ -55,3 +55,6 @@ class LibCTest(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             lib._missing_function(100)
+
+        with self.assertRaises(TypeError):
+            self.assertEqual(lib.abs("SPAM"), 3)


### PR DESCRIPTION
Closes #30

**Approach**
We defensively check whether the message field exists, and interpret the exception as a string if not.
