### PR TITLE
Add check that object is initialized before calling bound functions

### DIFF
--- a/cwrap/basecclass.py
+++ b/cwrap/basecclass.py
@@ -45,6 +45,9 @@ class BaseCClass(object):
 
         return obj
 
+    def is_initialized(self):
+        return self._address() is not None
+
     def _address(self):
         return self.__c_pointer
 

--- a/cwrap/prototype.py
+++ b/cwrap/prototype.py
@@ -214,6 +214,9 @@ class Prototype(object):
                 raise NotImplementedError("Function:%s has not been properly resolved" % self.__name__)
             else:
                 raise PrototypeError("Prototype has not been properly resolved")
+        if self._bind and not args[0].is_initialized():
+            raise ValueError("Called bound function with uninitialized object of type "
+                             f"{type(args[0]).__name__}")
         try:
             return self._func(*args)
         except ctypes.ArgumentError as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six
+pytest

--- a/tests/test_prototype.py
+++ b/tests/test_prototype.py
@@ -1,0 +1,29 @@
+from cwrap import BaseCClass, Prototype, load
+import os
+import pytest
+
+
+class LibCPrototype(Prototype):
+    lib = load("msvcrt" if os.name == "nt" else None)
+
+    def __init__(self, prototype, bind):
+        super(LibCPrototype, self).__init__(
+            LibCPrototype.lib,
+            prototype,
+            bind=bind)
+
+
+class BadInitialization(BaseCClass):
+    TYPE_NAME = "bad_initialization"
+    _abs = LibCPrototype("int abs(int)", bind=True)
+
+    def __init__(self):
+        self._abs(0)  # called before initialization, should raise
+
+    def free(self):
+        pass
+
+
+def test_that_unitialized_is_raised():
+    with pytest.raises(ValueError, match="uninitialized"):
+        _ = BadInitialization()


### PR DESCRIPTION
Need this so that debugger does not segfault.